### PR TITLE
[draft] add: basic nix support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "docopt-completion": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1733715402,
+        "narHash": "sha256-HIpj2byAozNHVjYxEzTD9qb8pYvYVqCtaLgjfyPQuHc=",
+        "path": "/home/shobu/Workspace/docopt-completion",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/shobu/Workspace/docopt-completion",
+        "type": "path"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733412085,
+        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1733412085,
+        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "docopt-completion": "docopt-completion",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,73 @@
+{
+  description = "A Nix-flake-based Python development environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  inputs.docopt-completion.url = "path:/home/shobu/Workspace/docopt-completion";
+
+  outputs = { self, nixpkgs, docopt-completion }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f rec {
+        pkgs = import nixpkgs { inherit system; };
+        pythonPackages = (with pkgs.python312Packages; [
+          docopt
+          jinja2
+          pyyaml
+          psutil
+          requests
+          scikit-learn
+          opencv-python
+          rich
+          typing-extensions
+          pydantic
+          pydantic-extra-types
+          numpy
+        ]);
+        pythonPackagesDev = (with pkgs.python312Packages; [
+          pytest
+          pytest-asyncio
+          mypy
+          black
+          types-requests
+          types-pyyaml
+          isort
+        ]);
+      });
+    in
+    {
+      packages = forEachSupportedSystem ({pkgs, pythonPackages, ...}: rec {
+        default = pkgs.python312Packages.buildPythonApplication rec {
+          pname = "pimpmyrice";
+          version = "0.3.0";
+
+          src = pkgs.fetchPypi {
+            inherit pname version;
+            hash = "sha256-J+V2GWHqJiGd931AOW00bNx3cAjumR72+kw7e3+tNxg=";
+          };
+
+          pyproject = true;
+
+          build-system = with pkgs.python312Packages; [
+            setuptools
+          ];
+
+          dependencies = [pythonPackages] ++ [docopt-completion.packages.${pkgs.system}.default];
+        };
+
+        pimpmyrice = default;
+      });
+
+      devShells = forEachSupportedSystem ({ pkgs, pythonPackages, pythonPackagesDev }: {
+        default = pkgs.mkShell {
+          venvDir = ".venv";
+          packages = with pkgs; [ python312 docopt-completion.packages.${system}.default ] ++
+            (with pkgs.python312Packages; [
+              pip
+              venvShellHook
+            ] ++
+            pythonPackages ++
+            pythonPackagesDev);
+        };
+      });
+    };
+}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     entry_points={"console_scripts": ["pimp=pimpmyrice.__main__:main"]},
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
-    python_requires=">=3.10",
+    python_requires=">=3.12",
     install_requires=[
         "docopt",
         "jinja2",


### PR DESCRIPTION
Started to add nix support to add on nixpkgs / local build.
- [x] make a propre repo for docopt-completion, presently hardcoded and not present in nixpkgs
- [ ] refactor
- [ ] FUTURE make module to handle declarative options. For now, usage is limited on nixos due to the current way of declaring theming option with homemanager overwritting pimpMyRice at each rebuild