### PR TITLE
update: change python version required in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     entry_points={"console_scripts": ["pimp=pimpmyrice.__main__:main"]},
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
-    python_requires=">=3.10",
+    python_requires=">=3.12",
     install_requires=[
         "docopt",
         "jinja2",


### PR DESCRIPTION
reuse of quote has been introduced in python 3.12, and will not work in version =< 3.11